### PR TITLE
[BACKEND] - changed login and register functionality to use httpyOnly…

### DIFF
--- a/backend/domains/auth/auth.controller.js
+++ b/backend/domains/auth/auth.controller.js
@@ -9,9 +9,14 @@ const login = async (req, res, next) => {
   const user = loginUser(username);
 
   //then generateToken
-  const token = generateToken(user);
+  const { token, expires } = generateToken(user);
 
-  res.type("json").send({ token: token, msg: "login success" });
+  // include cookie in response
+  // TODO: should we add a maxAge on the cookie, the same as the token expiration?
+  res
+    .type("json")
+    .cookie("token", token, { httpOnly: true }) // NOTE: in production, set secure: true
+    .send({ expires, isAuthSuccessful: true, msg: "login success" });
 };
 
 const register = async (req, res, next) => {
@@ -22,15 +27,20 @@ const register = async (req, res, next) => {
   const registeredUser = await registerUser(email, hashedPassword, username);
 
   // could add a verification step here for later
-  const token = generateToken(registeredUser.username, registeredUser.user_id);
-  res.type("json").send({
-    token: token,
-    user: {
-      username: registeredUser.username,
-      user_id: registeredUser.user_id,
-    },
-    msg: "register success",
-  });
+  const { token, expires } = generateToken(registeredUser.username, registeredUser.user_id);
+
+  res
+    .type("json")
+    .cookie("token", token, { httpOnly: true }) // NOTE: in production, set secure: true
+    .send({
+      user: {
+        username: registeredUser.username,
+        user_id: registeredUser.user_id,
+      },
+      expires,
+      isAuthSuccessful: true,
+      msg: "register success",
+    });
 };
 
 //change Password method

--- a/backend/domains/auth/jwt.js
+++ b/backend/domains/auth/jwt.js
@@ -1,10 +1,16 @@
 const { sign, verify } = require("jsonwebtoken");
 const { config } = require("../../config");
 
+// Expiration duration in seconds
+const expiresInSeconds = 3600; // 1 hour
+
 const generateToken = (user) => {
   const {
     jwt: { secret, issuer, audience },
   } = config;
+
+  // Calculate the expiration time
+  const expires = Date.now() + expiresInSeconds * 1000;
 
   const token = sign(
     {
@@ -13,7 +19,7 @@ const generateToken = (user) => {
     },
     secret,
     {
-      expiresIn: "1h",
+      expiresIn: expiresInSeconds,
       notBefore: "0",
       algorithm: "HS256",
       audience: audience,
@@ -21,7 +27,7 @@ const generateToken = (user) => {
     }
   );
 
-  return token;
+  return { token, expires };
 };
 
 module.exports = { generateToken };


### PR DESCRIPTION
Slight changes to the backend regarding authentication so it works with our httpyOnly cookie approach:

- The function generateToken() now calculates and returns the expiration date along with the jwt token. (The current implementation is a bit hacky but I'm not sure what would be a better workaround. It should still work correctly in all authentication scenarios.)
- The server now sends jwt tokens as httpOnly cookies.

So for when we are doing authenticated requests on the backend - the token will now be stored in the request cookie with the key 'token'.

This might also be useful:
https://vivekkrishnavk.medium.com/using-jwts-as-http-only-cookies-with-react-js-a301991fdfa6

